### PR TITLE
Added monitoring of multiple services

### DIFF
--- a/Wack-A-Mole.ps1
+++ b/Wack-A-Mole.ps1
@@ -89,8 +89,8 @@ while ($wack -eq "true") {
             #try to start service
             Start-Service -Name $serviceName
 
-            #if service is now enabled
-            if ((Get-Service $serviceName).Status -eq "Enabled") {
+            #if service is now starting or running
+            if ((Get-Service $serviceName).Status -Match "Running|StartPending") { 
 
                 #display artifacts
                 write-host $serviceName" is now running."

--- a/Wack-A-Mole.ps1
+++ b/Wack-A-Mole.ps1
@@ -8,9 +8,10 @@ Write-Host "This tactic that is meant to buy time while defenders can identify h
 #configure execution policy so script runs
 Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Bypass -Force
 
+$monitoredServiceList = [System.Collections.ArrayList]::new()
 
 #list of services to monitor, Last item is entering manual name
-Write-Host "Select a service to monitor"
+Write-Host "Select which services to monitor (separated by commas)"
 Write-Host "#1 FTP"
 Write-Host "#2 HTTP"
 Write-Host "#3 HTTPS"
@@ -22,89 +23,95 @@ Write-Host "#8 telnet"
 Write-Host "#9 Custom"
 
 #prompt user for number
-$optionNumber = read-host "Select a number from above list: "
+$optionNumbers = read-host "Select a number from above list: "
 
-#Nine if statements to determine the $serviceName Value based on user input
-if ($optionNumber -eq 1){
-    $serviceName = "FTP"
-}
-if ($optionNumber -eq 2){
-    $serviceName = "HTTP"
-}
-if ($optionNumber -eq 3){
-    $serviceName = "HTTPS"
-}
-if ($optionNumber -eq 4){
-    $serviceName = "SMB"
-}
-if ($optionNumber -eq 5){
-    $serviceName = "DNS"
-}
-if ($optionNumber -eq 6){
-    $serviceName = "VNC"
-}
-if ($optionNumber -eq 7){
-    $serviceName = "SSH"
-}
-if ($optionNumber -eq 8){
-    $serviceName = "Telnet"
-}
-if ($optionNumber -eq 9){
-    #This last option promps user for custom service not listed above
-    $serviceName = Read-Host "Enter Service Name (not display name), confirm after setup that script is running correctly"
-}
+foreach ($option in $optionNumbers.Split(",")) {
+    $option = $option.trim() #Remove whitespace left over from Split()
 
+    #Nine if statements to determine the $serviceName Value based on user input
+    if ($option -eq 1) {
+        $serviceName = "FTP"
+    }
+    if ($option -eq 2) {
+        $serviceName = "HTTP"
+    }
+    if ($option -eq 3) {
+        $serviceName = "HTTPS"
+    }
+    if ($option -eq 4) {
+        $serviceName = "SMB"
+    }
+    if ($option -eq 5) {
+        $serviceName = "DNS"
+    }
+    if ($option -eq 6) {
+        $serviceName = "VNC"
+    }
+    if ($option -eq 7) {
+        $serviceName = "SSH"
+    }
+    if ($option -eq 8) {
+        $serviceName = "Telnet"
+    }
+    if ($option -eq 9) {
+        #This last option promps user for custom service not listed above
+        $serviceName = Read-Host "Enter Service Name (not display name), confirm after setup that script is running correctly"
+    }
+    $monitoredServiceList.Add($serviceName) #Add service name to monitoring list
+}
 #formatting
 Write-host "---------------------------------------------------------------------------------------------------------"
 
 #while true loop
 $wack = "true"
-while ($wack -eq "true"){
+while ($wack -eq "true") {
+    foreach ($serviceName in $monitoredServiceList) {
 
-    #check if service is up, 
-    if ((Get-Service $serviceName).Status -eq "Running"){
-
-        #display artifacts
-        Write-Host $serviceName" is Running"
-        (Get-Date).ToString('G')
-        Get-Service $serviceName | Format-Table serviceName, displayName, startType, status
-
-
-    }
-
-    #if service is Not enabled
-    if ((Get-Service $serviceName).Status -ne "Running"){
-
-        #display artifacts
-        write-host $serviceName" is not running. Attempting to start service."
-        (Get-Date).ToString('G')
-        Get-Service $serviceName | Format-Table serviceName, displayName, startType, status
-
-        #try to start service
-        Start-Service -Name $serviceName
-
-        #if service is now enabled
-        if ((Get-Service $serviceName).Status -eq "Enabled"){
+        #check if service is up, 
+        if ((Get-Service $serviceName).Status -eq "Running") {
 
             #display artifacts
-            write-host $serviceName" is now running."
+            Write-Host $serviceName" is Running"
             (Get-Date).ToString('G')
             Get-Service $serviceName | Format-Table serviceName, displayName, startType, status
+
+
         }
-        
-        #if service is still not running after the above attempt to get it running
-        if ((Get-Service $serviceName).Status -ne "Running"){
+
+        #if service is Not enabled
+        if ((Get-Service $serviceName).Status -ne "Running") {
 
             #display artifacts
-            write-host "Unable to start "$serviceName". Investigate before the mole wacks you."
+            write-host $serviceName" is not running. Attempting to start service."
             (Get-Date).ToString('G')
-
             Get-Service $serviceName | Format-Table serviceName, displayName, startType, status
 
-            #stops while loop so Incident responder can investigate
-            $wack = "false"
+            #try to start service
+            Start-Service -Name $serviceName
 
-            #wacked ascii art here
+            #if service is now enabled
+            if ((Get-Service $serviceName).Status -eq "Enabled") {
+
+                #display artifacts
+                write-host $serviceName" is now running."
+                (Get-Date).ToString('G')
+                Get-Service $serviceName | Format-Table serviceName, displayName, startType, status
+            }
+        
+            #if service is still not running after the above attempt to get it running
+            if ((Get-Service $serviceName).Status -ne "Running") {
+
+                #display artifacts
+                write-host "Unable to start "$serviceName". Investigate before the mole wacks you."
+                (Get-Date).ToString('G')
+
+                Get-Service $serviceName | Format-Table serviceName, displayName, startType, status
+
+                #stops while loop so Incident responder can investigate
+                $wack = "false"
+
+                #wacked ascii art here
+            }
         }
     }
 
@@ -114,10 +121,10 @@ while ($wack -eq "true"){
 
 
     #potental new features
-        #write output to log
-        #user can pause loop to look at output
-            #check for input, timeout
-
+    #write output to log
+    #user can pause loop to look at output
+    #check for input, timeout
+    
 } # end of while loop
 
 #reference


### PR DESCRIPTION
Added ability to monitor multiple services in a single session.

[275ff49](https://github.com/Epidemic41/Wack-A-Mole/pull/1/commits/275ff49449809a766c17cd7571e602606c8d3717):  Changed the status check to either 'Running' or 'StartPending'. The code inside the conditional on line 93 will never run because 'Enabled' isn't a valid status, see [this](https://learn.microsoft.com/en-us/dotnet/api/system.serviceprocess.servicecontrollerstatus?view=dotnet-plat-ext-7.0) article for a list of possible options.