### PR TITLE
Automatic detection of relevant services in categories

### DIFF
--- a/Wack-A-Mole.ps1
+++ b/Wack-A-Mole.ps1
@@ -11,24 +11,24 @@ Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Bypass -Force
 $monitoredServiceList = [System.Collections.ArrayList]::new()
 
 class ServiceListEntry {
-    [ValidateNotNullOrEmpty()][string]$DisplayName      #Eg. 'FTP' for FTP related services
-    [ValidateNotNullOrEmpty()][string[]]$Services       #Eg. 'filezilla-server'
+    [ValidateNotNullOrEmpty()][string]$DisplayName      #eg. 'FTP' for FTP related services
+    [ValidateNotNullOrEmpty()][string[]]$Services       #eg. 'filezilla-server'
 }
 
 $servicesList = [ServiceListEntry[]]@(
     [ServiceListEntry]@{
         DisplayName = "FTP"
         Services    = @(
-            "FTPSVC",               #IIS FTP Server
-            "filezilla-server"      #Filezilla FTP Server
+            "FTPSVC",           #IIS FTP Server
+            "filezilla-server"  #Filezilla FTP Server
         )
     },
     [ServiceListEntry]@{
         DisplayName = "HTTP/HTTPS"
         Services    = @(
-            "HTTP",                 #The HTTP 'service' is actually a driver needed for the Print Spooler, see https://superuser.com/questions/1059068/no-http-service-windows-10
+            "HTTP",             #the HTTP 'service' is actually a driver needed for the Print Spooler, see https://superuser.com/questions/1059068/no-http-service-windows-10
             
-            #IIS Services (https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/jj635851(v=ws.11), https://docs.oracle.com/en/industries/health-sciences/inform/cognos1117-install/index.html?toc.htm?226411.htm)
+            #IIS Services
             "W3SVC",
             "W3LOGSVC",
             "WAS"
@@ -63,27 +63,27 @@ Write-Host "#$($servicesList.Length + 1) Custom" #Custom option
 $optionNumbers = read-host "Select a number from above list: "
 
 foreach ($option in $optionNumbers.Split(",")) {
-    $option = $option.trim() #Remove whitespace left over from Split()
+    $option = $option.trim() #remove whitespace left over from Split()
 
     if ($option -le $servicesList.Length) {
 
         #true if any of the group of services under the display name exist on the system 
         $displayNameHasExistentServices = $false;
 
-        #Get all services listed under the display name
+        #get all services listed under the display name
         $servicesList[[int]$option - 1].Services | ForEach-Object {
 
-            #Assigns the service under the display name to the watched services list if it exists on the system 
-            # (eg. When selecting the 'FTP' option, fillezilla-server will be added to the list but FTPSrv won't since IIS isn't installed); ignores if service doesn't exist
+            #assigns the service under the display name to the watched services list if it exists on the system 
+            # (eg. When selecting the 'FTP' option, fillezilla-server will be added to the list but FTPSrv won't if the IIS FTP Server feature isn't installed); ignores silently if service doesn't exist
             $serviceExists = Get-Service -Name $_ -ErrorAction SilentlyContinue
             if ($null -ne $serviceExists) {
-                $monitoredServiceList.Add($_) #Add previously existing service name to monitoring list
+                $monitoredServiceList.Add($_) #add previously existing service name to monitoring list
 
                 $displayNameHasExistentServices = $true
             }
         }
 
-        #Warn the user when attempting to add a set of services that don't exist
+        #warn the user when attempting to add a set of services that don't exist
         if ($displayNameHasExistentServices -eq $false) {
             $serviceListEntry = $servicesList[[int]$option - 1]
             $displayName = $serviceListEntry.DisplayName
@@ -95,7 +95,7 @@ foreach ($option in $optionNumbers.Split(",")) {
     else {
         #This last option promps user for custom service not listed above
         $serviceName = Read-Host "Enter Service Name (not display name), confirm after setup that script is running correctly"
-        $monitoredServiceList.Add($serviceName) #Add custom service name to monitoring list
+        $monitoredServiceList.Add($serviceName) #add custom service name to monitoring list
     }
     
 }
@@ -169,3 +169,6 @@ while ($wack -eq "true") {
 
 #reference
 #https://social.technet.microsoft.com/Forums/windowsserver/en-US/79bf9de7-1c17-45c0-a02b-7558af89807a/powershell-script-to-check-service-status
+#IIS Services 
+# https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/jj635851(v=ws.11), 
+# https://docs.oracle.com/en/industries/health-sciences/inform/cognos1117-install/index.html?toc.htm?226411.htm)

--- a/Wack-A-Mole.ps1
+++ b/Wack-A-Mole.ps1
@@ -89,8 +89,8 @@ while ($wack -eq "true") {
             #try to start service
             Start-Service -Name $serviceName
 
-            #if service is now enabled
-            if ((Get-Service $serviceName).Status -eq "Enabled") {
+            #if service is now starting or running
+            if ((Get-Service $serviceName).Status -Match "Running|StartPending") { 
 
                 #display artifacts
                 write-host $serviceName" is now running."

--- a/Wack-A-Mole.ps1
+++ b/Wack-A-Mole.ps1
@@ -18,38 +18,38 @@ class ServiceListEntry {
 $servicesList = [ServiceListEntry[]]@(
     [ServiceListEntry]@{
         DisplayName = "FTP"
-        Services = @("FTP")
+        Services    = @("FTP")
     },
     [ServiceListEntry]@{
         DisplayName = "HTTP"
-        Services = @("HTTP")
+        Services    = @("HTTP")
     },
     [ServiceListEntry]@{
         DisplayName = "HTTPS"
-        Services = @("HTTPS")
+        Services    = @("HTTPS")
     },
     [ServiceListEntry]@{
         DisplayName = "SMB"
-        Services = @("SMB")
+        Services    = @("SMB")
     },
     [ServiceListEntry]@{
         DisplayName = "DNS"
-        Services = @("DNS")
+        Services    = @("DNS")
     },
     [ServiceListEntry]@{
         DisplayName = "VNC"
-        Services = @("VNC")
+        Services    = @("VNC")
     },
     [ServiceListEntry]@{
         DisplayName = "telnet"
-        Services = @("Telnet")
+        Services    = @("Telnet")
     }
 )
 
 #list of services to monitor, Last item is entering manual name
 Write-Host "Select which services to monitor (separated by commas)"
 
-$servicesList | ForEach-Object {$index=1} { Write-Host "#$($index)" $_.DisplayName; $index++ }  #Print display name of all registered services 
+$servicesList | ForEach-Object { $index = 1 } { Write-Host "#$($index)" $_.DisplayName; $index++ }  #Print display name of all registered services 
 
 Write-Host "#$($servicesList.Length + 1) Custom" #Custom option
 
@@ -59,7 +59,7 @@ $optionNumbers = read-host "Select a number from above list: "
 foreach ($option in $optionNumbers.Split(",")) {
     $option = $option.trim() #Remove whitespace left over from Split()
 
-    if($option -le $servicesList.Length) {
+    if ($option -le $servicesList.Length) {
 
         #Get all services listed under the display name
         $servicesList[[int]$option - 1].Services | ForEach-Object {
@@ -67,7 +67,7 @@ foreach ($option in $optionNumbers.Split(",")) {
             #Assigns the service under the display name to the watched services list if it exists on the system 
             # (eg. When selecting the 'FTP' option, fillezilla-server will be added to the list but FTPSrv won't since IIS isn't installed); ignores if service doesn't exist
             $serviceExists = Get-Service -Name $_ -ErrorAction SilentlyContinue
-            if($null -ne $serviceExists){
+            if ($null -ne $serviceExists) {
                 $monitoredServiceList.Add($_) #Add previously existing service name to monitoring list
             }
         }

--- a/Wack-A-Mole.ps1
+++ b/Wack-A-Mole.ps1
@@ -61,6 +61,9 @@ foreach ($option in $optionNumbers.Split(",")) {
 
     if ($option -le $servicesList.Length) {
 
+        #true if any of the group of services under the display name exist on the system 
+        $displayNameHasExistentServices = $false;
+
         #Get all services listed under the display name
         $servicesList[[int]$option - 1].Services | ForEach-Object {
 
@@ -69,7 +72,18 @@ foreach ($option in $optionNumbers.Split(",")) {
             $serviceExists = Get-Service -Name $_ -ErrorAction SilentlyContinue
             if ($null -ne $serviceExists) {
                 $monitoredServiceList.Add($_) #Add previously existing service name to monitoring list
+
+                $displayNameHasExistentServices = $true
             }
+        }
+
+        #Warn the user when attempting to add a set of services that don't exist
+        if($displayNameHasExistentServices -eq $false) {
+            $serviceListEntry = $servicesList[[int]$option - 1]
+            $displayName = $serviceListEntry.DisplayName
+
+            Write-Warning "No services under group '$displayName' are present on this system! ($($serviceListEntry.Services -join ", "))"
+            Write-Warning "Check selection(s) from above are entered correctly."
         }
     }
     else {

--- a/Wack-A-Mole.ps1
+++ b/Wack-A-Mole.ps1
@@ -18,7 +18,10 @@ class ServiceListEntry {
 $servicesList = [ServiceListEntry[]]@(
     [ServiceListEntry]@{
         DisplayName = "FTP"
-        Services    = @("FTP")
+        Services    = @(
+            "FTPSVC",               #IIS FTP Server
+            "filezilla-server"      #Filezilla FTP Server
+        )
     },
     [ServiceListEntry]@{
         DisplayName = "HTTP"
@@ -78,7 +81,7 @@ foreach ($option in $optionNumbers.Split(",")) {
         }
 
         #Warn the user when attempting to add a set of services that don't exist
-        if($displayNameHasExistentServices -eq $false) {
+        if ($displayNameHasExistentServices -eq $false) {
             $serviceListEntry = $servicesList[[int]$option - 1]
             $displayName = $serviceListEntry.DisplayName
 

--- a/Wack-A-Mole.ps1
+++ b/Wack-A-Mole.ps1
@@ -25,7 +25,14 @@ $servicesList = [ServiceListEntry[]]@(
     },
     [ServiceListEntry]@{
         DisplayName = "HTTP/HTTPS"
-        Services    = @("HTTP", "HTTPS")
+        Services    = @(
+            "HTTP",                 #The HTTP 'service' is actually a driver needed for the Print Spooler, see https://superuser.com/questions/1059068/no-http-service-windows-10
+            
+            #IIS Services (https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/jj635851(v=ws.11), https://docs.oracle.com/en/industries/health-sciences/inform/cognos1117-install/index.html?toc.htm?226411.htm)
+            "W3SVC",
+            "W3LOGSVC",
+            "WAS"
+        )
     },
     [ServiceListEntry]@{
         DisplayName = "SMB"

--- a/Wack-A-Mole.ps1
+++ b/Wack-A-Mole.ps1
@@ -8,9 +8,10 @@ Write-Host "This tactic that is meant to buy time while defenders can identify h
 #configure execution policy so script runs
 Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Bypass -Force
 
+$monitoredServiceList = [System.Collections.ArrayList]::new()
 
 #list of services to monitor, Last item is entering manual name
-Write-Host "Select a service to monitor"
+Write-Host "Select which services to monitor (separated by commas)"
 Write-Host "#1 FTP"
 Write-Host "#2 HTTP"
 Write-Host "#3 HTTPS"
@@ -22,89 +23,95 @@ Write-Host "#8 telnet"
 Write-Host "#9 Custom"
 
 #prompt user for number
-$optionNumber = read-host "Select a number from above list: "
+$optionNumbers = read-host "Select a number from above list: "
 
-#Nine if statements to determine the $serviceName Value based on user input
-if ($optionNumber -eq 1){
-    $serviceName = "FTP"
-}
-if ($optionNumber -eq 2){
-    $serviceName = "HTTP"
-}
-if ($optionNumber -eq 3){
-    $serviceName = "HTTPS"
-}
-if ($optionNumber -eq 4){
-    $serviceName = "SMB"
-}
-if ($optionNumber -eq 5){
-    $serviceName = "DNS"
-}
-if ($optionNumber -eq 6){
-    $serviceName = "VNC"
-}
-if ($optionNumber -eq 7){
-    $serviceName = "SSH"
-}
-if ($optionNumber -eq 8){
-    $serviceName = "Telnet"
-}
-if ($optionNumber -eq 9){
-    #This last option promps user for custom service not listed above
-    $serviceName = Read-Host "Enter Service Name (not display name), confirm after setup that script is running correctly"
-}
+foreach ($option in $optionNumbers.Split(",")) {
+    $option = $option.trim() #Remove whitespace left over from Split()
 
+    #Nine if statements to determine the $serviceName Value based on user input
+    if ($option -eq 1) {
+        $serviceName = "FTP"
+    }
+    if ($option -eq 2) {
+        $serviceName = "HTTP"
+    }
+    if ($option -eq 3) {
+        $serviceName = "HTTPS"
+    }
+    if ($option -eq 4) {
+        $serviceName = "SMB"
+    }
+    if ($option -eq 5) {
+        $serviceName = "DNS"
+    }
+    if ($option -eq 6) {
+        $serviceName = "VNC"
+    }
+    if ($option -eq 7) {
+        $serviceName = "SSH"
+    }
+    if ($option -eq 8) {
+        $serviceName = "Telnet"
+    }
+    if ($option -eq 9) {
+        #This last option promps user for custom service not listed above
+        $serviceName = Read-Host "Enter Service Name (not display name), confirm after setup that script is running correctly"
+    }
+    $monitoredServiceList.Add($serviceName) #Add service name to monitoring list
+}
 #formatting
 Write-host "---------------------------------------------------------------------------------------------------------"
 
 #while true loop
 $wack = "true"
-while ($wack -eq "true"){
+while ($wack -eq "true") {
+    foreach ($serviceName in $monitoredServiceList) {
 
-    #check if service is up, 
-    if ((Get-Service $serviceName).Status -eq "Running"){
-
-        #display artifacts
-        Write-Host $serviceName" is Running"
-        (Get-Date).ToString('G')
-        Get-Service $serviceName | Format-Table serviceName, displayName, startType, status
-
-
-    }
-
-    #if service is Not enabled
-    if ((Get-Service $serviceName).Status -ne "Running"){
-
-        #display artifacts
-        write-host $serviceName" is not running. Attempting to start service."
-        (Get-Date).ToString('G')
-        Get-Service $serviceName | Format-Table serviceName, displayName, startType, status
-
-        #try to start service
-        Start-Service -Name $serviceName
-
-        #if service is now enabled
-        if ((Get-Service $serviceName).Status -eq "Enabled"){
+        #check if service is up, 
+        if ((Get-Service $serviceName).Status -eq "Running") {
 
             #display artifacts
-            write-host $serviceName" is now running."
+            Write-Host $serviceName" is Running"
             (Get-Date).ToString('G')
             Get-Service $serviceName | Format-Table serviceName, displayName, startType, status
+
+
         }
-        
-        #if service is still not running after the above attempt to get it running
-        if ((Get-Service $serviceName).Status -ne "Running"){
+
+        #if service is Not enabled
+        if ((Get-Service $serviceName).Status -ne "Running") {
 
             #display artifacts
-            write-host "Unable to start "$serviceName". Investigate before the mole wacks you."
+            write-host $serviceName" is not running. Attempting to start service."
             (Get-Date).ToString('G')
-
             Get-Service $serviceName | Format-Table serviceName, displayName, startType, status
 
-            #stops while loop so Incident responder can investigate
-            $wack = "false"
+            #try to start service
+            Start-Service -Name $serviceName
 
-            #wacked ascii art here
+            #if service is now enabled
+            if ((Get-Service $serviceName).Status -eq "Enabled") {
+
+                #display artifacts
+                write-host $serviceName" is now running."
+                (Get-Date).ToString('G')
+                Get-Service $serviceName | Format-Table serviceName, displayName, startType, status
+            }
+        
+            #if service is still not running after the above attempt to get it running
+            if ((Get-Service $serviceName).Status -ne "Running") {
+
+                #display artifacts
+                write-host "Unable to start "$serviceName". Investigate before the mole wacks you."
+                (Get-Date).ToString('G')
+
+                Get-Service $serviceName | Format-Table serviceName, displayName, startType, status
+
+                #stops while loop so Incident responder can investigate
+                $wack = "false"
+
+                #wacked ascii art here
+            }
         }
     }
 
@@ -114,10 +121,10 @@ while ($wack -eq "true"){
 
 
     #potental new features
-        #write output to log
-        #user can pause loop to look at output
-            #check for input, timeout
-
+    #write output to log
+    #user can pause loop to look at output
+    #check for input, timeout
+    
 } # end of while loop
 
 #reference

--- a/Wack-A-Mole.ps1
+++ b/Wack-A-Mole.ps1
@@ -68,15 +68,16 @@ foreach ($option in $optionNumbers.Split(",")) {
             # (eg. When selecting the 'FTP' option, fillezilla-server will be added to the list but FTPSrv won't since IIS isn't installed); ignores if service doesn't exist
             $serviceExists = Get-Service -Name $_ -ErrorAction SilentlyContinue
             if($null -ne $serviceExists){
-                $serviceName = $_
+                $monitoredServiceList.Add($_) #Add previously existing service name to monitoring list
             }
         }
     }
     else {
         #This last option promps user for custom service not listed above
         $serviceName = Read-Host "Enter Service Name (not display name), confirm after setup that script is running correctly"
+        $monitoredServiceList.Add($serviceName) #Add custom service name to monitoring list
     }
-    $monitoredServiceList.Add($serviceName) #Add service name to monitoring list
+    
 }
 #formatting
 Write-host "---------------------------------------------------------------------------------------------------------"

--- a/Wack-A-Mole.ps1
+++ b/Wack-A-Mole.ps1
@@ -24,12 +24,8 @@ $servicesList = [ServiceListEntry[]]@(
         )
     },
     [ServiceListEntry]@{
-        DisplayName = "HTTP"
-        Services    = @("HTTP")
-    },
-    [ServiceListEntry]@{
-        DisplayName = "HTTPS"
-        Services    = @("HTTPS")
+        DisplayName = "HTTP/HTTPS"
+        Services    = @("HTTP", "HTTPS")
     },
     [ServiceListEntry]@{
         DisplayName = "SMB"


### PR DESCRIPTION
This PR makes several changes but is largely based off of #1 and consolidates the different services into categories, where upon selecting one will automatically detect services which are actually installed. 
This allows us to preload a wider range of services for programs that we suspect to encounter during the competition that we want to monitor and moving the burden from the user trying to identify what's on the system and leaving the heavy lifting to the script.